### PR TITLE
Add parameter to skip automatic Vault unseal (#11)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -27,6 +27,12 @@ credentials used elsewhere in deployments and applications.
   names the availability set to deploy the Vault nodes across.
   This parameter does not have any effect on other platforms.
 
+- `auxiliary_vault` - If deploying a second Vault after the 
+  primary Genesis Vault was deployed. This prevents automatic
+  unsealing of the Vault after a deploy, as Genesis will attempt 
+  to unseal the new Vault with the seal keys of the primary 
+  Genesis Vault. Defaults to `false`.
+
 # Cloud Configuration
 
 By default, Vault uses the following VM types/networks/disk pools from your

--- a/ci/envs/ci-baseline.yml
+++ b/ci/envs/ci-baseline.yml
@@ -6,6 +6,7 @@ params:
   env:   ci-baseline
   vault: genesis-ci/vault/ci/baseline
   bosh:  genesis-ci
+  auxiliary_vault: true
 
   vault_network: genesis-ci
   vault_vm_type: small

--- a/hooks/new
+++ b/hooks/new
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+# Skip auto unseal if auxiliary
+prompt_for genesis_vault boolean \
+  'Is this your Genesis Vault (for storing deployment credentials)?'
+
 (
 echo "---"
 echo "kit:"
@@ -10,11 +14,8 @@ echo
 echo "params:"
 echo "  env: $GENESIS_ENVIRONMENT"
 
-) >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
-
-# Skip auto unseal if auxiliary
-prompt_for auxiliary_vault boolean \
-	'Is this your Genesis Vault (for storing deployment credentials)?'
- if [ $auxiliary_vault != "true" ] ; then
-  echo "  auxiliary_vault: true" >>$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
+if [ $genesis_vault != "true" ] ; then
+  echo "  auxiliary_vault: true"
 fi
+
+) >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml

--- a/hooks/new
+++ b/hooks/new
@@ -11,3 +11,10 @@ echo "params:"
 echo "  env: $GENESIS_ENVIRONMENT"
 
 ) >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
+
+# Skip auto unseal if auxiliary
+prompt_for auxiliary_vault boolean \
+	'Is this your Genesis Vault (for storing deployment credentials)?'
+ if [ $auxiliary_vault != "true" ] ; then
+  echo "  auxiliary_vault: true" >>$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
+fi

--- a/hooks/post-deploy
+++ b/hooks/post-deploy
@@ -7,7 +7,7 @@ if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
   describe "#M{$GENESIS_ENVIRONMENT} Vault deployed!"
       echo
 
-  if [[ -f "$GENESIS_PREDEPLOY_DATAFILE" ]] ; then
+  if [[ -f "$GENESIS_PREDEPLOY_DATAFILE" &&  $(lookup params.auxiliary_vault) != "true" ]] ; then
       echo "Unsealing the vault..."
     safe -T $GENESIS_ENVIRONMENT unseal < $GENESIS_PREDEPLOY_DATAFILE
   else

--- a/hooks/pre-deploy
+++ b/hooks/pre-deploy
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -eu
 
+# a quick explanation here:
+# secret/vault/seal/keys stores the vault's unseal keys they're placed
+# there by `safe init`, and it's for whizbang things like automatically
+# unsealing the vault after a redeploy.
+# now, this breaks down if you're already targeting a vault that's been
+# initialized via safe and go to deploy another vault, because it'll look
+# for seal keys in your existing vault, and pass them to `post-deploy`;
+# which will fail because it grabbed the wrong seal keys. which is why
+# it's necessary to set `params.auxiliary_vault` to true so that the
+# automatic unseal isn't attempted.
+#
+# note that this does not affect the "first" vault that's setup via
+# `safe local --memory` because that does not contain seal keys as
+# it's memory backed. so an unseal is not attempted because it
+# couldn't find the seal keys.
+#
+# it's like magic!
 i=1
 (while safe exists "secret/vault/seal/keys:key$i"; do
   safe read "secret/vault/seal/keys:key$i"


### PR DESCRIPTION
This PR adds `params.auxiliary_vault`, which will cause the kit to bypass automatic vault unseal after a deploy. Previously, if an operator were to deploy a second Vault (not to be used for Genesis), an automatic unseal would fail because this kit was expecting to be deployed via a `safe local --memory` Vault backing it. Thus, the unseal logic would check for existing seal keys (which would be absent as the `safe local --memory` Vault does not contain any), and not attempt an automatic unseal. Worked great.

However, once that primary Vault is now deployed, an attempt to deploy a secondary Vault would fail during `post-deploy` execution as the kit would look for existing seal keys (which it would find because the primary Vault has seal keys) and go to unseal it with the seal keys of the primary Vault.

This functionality can now be skipped by setting `params.auxiliary_vault` to `true` (defaults to false). This is to be used with non-Genesis usage related Vaults. This fixes #11.