### PR TITLE
Use Xenial stemcells by default

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -23,6 +23,12 @@ credentials used elsewhere in deployments and applications.
   must be defined in your cloud config.  Defaults to `z1`, `z2`,
   and `z3`.
 
+- `stemcell_os` - The operating system stemcell you want to deploy
+  on. (default: `ubuntu-xenial`)
+  
+- `stemcell_version` - The specific version of the stemcell you want
+  to deploy on. (default: `latest`)
+
 - `azure_availability_set` - In Microsoft Azure, this parameter
   names the availability set to deploy the Vault nodes across.
   This parameter does not have any effect on other platforms.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Improvements
+
+- Use Xenial stemcells by default

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -42,5 +42,5 @@ releases:
 
 stemcells:
 - alias:   default
-  os:      (( grab params.stemcell_os      || "ubuntu-trusty" ))
+  os:      (( grab params.stemcell_os      || "ubuntu-xenial" ))
   version: (( grab params.stemcell_version || "latest"        ))


### PR DESCRIPTION
This PR configures the kit to use Xenial stemcells by default. Tested and verified to work with `97.latest`