### PR TITLE
Bump to safe-boshrelease v0.2.1

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+# Software Updates
+
+* safe-boshrelease bumped to 0.2.1
+
+# New Features
+
+Now supports versioned secrets.  See output of post-deploy summary for details
+on enabling this feature.

--- a/hooks/post-deploy
+++ b/hooks/post-deploy
@@ -9,7 +9,7 @@ if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
 
   if [[ -f "$GENESIS_PREDEPLOY_DATAFILE" &&  $(lookup params.auxiliary_vault) != "true" ]] ; then
       echo "Unsealing the vault..."
-    safe -T $GENESIS_ENVIRONMENT unseal < $GENESIS_PREDEPLOY_DATAFILE
+    safe -T "$GENESIS_ENVIRONMENT" unseal < "$GENESIS_PREDEPLOY_DATAFILE"
   else
       echo "Unable to unseal the vault.  If this is a new deployment,"
       echo "you will need to initalize the vault first."
@@ -20,14 +20,26 @@ if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
       echo
   describe "  #G{genesis info $GENESIS_ENVIRONMENT}"
       echo
-      echo "Before you can use the Vault, you will need"
-      echo "to initialize it first.  To do so, run"
+      echo "Before you can use the Vault, you will need to initialize it"
+      echo "first.  To do so, run"
       echo
   describe "  #G{genesis do $GENESIS_ENVIRONMENT -- init}"
       echo
-      echo "If this was not the initial deployment of the"
-      echo "Vault, you will need to unseal it, via"
+      echo "If this was not the initial deployment of the Vault, you will"
+      echo "need to unseal it, via"
       echo
   describe "  #G{genesis do $GENESIS_ENVIRONMENT -- unseal}"
+      echo
+      echo "This version of Vault supports versioning secrets, but it is"
+      echo "disabled by default.  To turn it on, you must run"
+      echo
+  describe "  #G{safe vault kv enable-versioning secret}"
+      echo
+      echo "You will need to be authorised with the root token, and have"
+      echo "Vault v0.11.0 or higher installed locally to perform this."
+      echo
+  describe "#Y{NOTE:} Once versioning is turned on for a secrets backend, it"
+      echo "cannot be turned off without deleting and recreating that"
+      echo "backend."
       echo
 fi

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -36,9 +36,9 @@ update:
 
 releases:
 - name: safe
-  version: 0.2.0
-  url: https://github.com/cloudfoundry-community/safe-boshrelease/releases/download/v0.2.0/safe-0.2.0.tgz
-  sha1: 417956a970faa348aebc7afd4d1f029395bb3719
+  version: 0.2.1
+  url: https://github.com/cloudfoundry-community/safe-boshrelease/releases/download/v0.2.1/safe-0.2.1.tgz
+  sha1: 7da89b2a385c3dfe3dc647844a61e8b531e6e54b
 
 stemcells:
 - alias:   default


### PR DESCRIPTION
This version of `safe-boshrelease` enables secrets versioning

Includes description on how to turn on secrets versioning in post-deploy
output.