### PR TITLE
Moved instance-group level properties to job level

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Kit Breaking Changes
+
+* Moved properties for vault job from instance-group level to job level. This
+	is due to support for instance-group level properties being dropped by new
+	versions of BOSH.

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -8,7 +8,17 @@ exodus:
 instance_groups:
 - name: vault
   jobs:
-    - { release: safe,     name: vault }
+  - name: vault
+    release: safe
+    properties:
+      safe:
+        ui: (( grab params.ui || true ))
+        peer:
+          tls:
+            certificate: (( vault meta.vault "/certs/consul:certificate" ))
+            key:         (( vault meta.vault "/certs/consul:key" ))
+            ca:          (( vault meta.vault "/certs/ca:certificate" ))
+
   instances: 3
   azs:       (( grab params.availability_zones || meta.default.azs ))
 
@@ -19,14 +29,6 @@ instance_groups:
   networks:
   - name:       (( grab params.vault_network || "vault" ))
     static_ips: (( static_ips(0, 1, 2) ))
-  properties:
-    safe:
-      ui: (( grab params.ui || true ))
-      peer:
-        tls:
-          certificate: (( vault meta.vault "/certs/consul:certificate" ))
-          key:         (( vault meta.vault "/certs/consul:key" ))
-          ca:          (( vault meta.vault "/certs/ca:certificate" ))
 
 update:
   serial: true


### PR DESCRIPTION
Due to new versions of BOSH dropping support for instance group level properties.