### PR TITLE
Update vault version and fix vault certs

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -41,6 +41,8 @@ credentials used elsewhere in deployments and applications.
 
 - `ui` - If true, the Vault Web UI will be turned on. Defaults to true.
 
+- `vault_domain` - Domain for vault certs to be signed for. Defaults to `vault.bosh`
+
 # Cloud Configuration
 
 By default, Vault uses the following VM types/networks/disk pools from your

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -3,3 +3,10 @@
 * Moved properties for vault job from instance-group level to job level. This
 	is due to support for instance-group level properties being dropped by new
 	versions of BOSH.
+
+# Updates
+
+* Bumped version of Vault to 1.4.0
+* Added `params.vault_domain` to allow setting the DNS SAN for the vault certs.
+* Certificates for Vault are now generted by genesis for a TTL of 2y to satisfy new browser certificate constraints
+	* You may need to run `genesis add-secrets` when upgrading to this version of the kit.

--- a/kit.yml
+++ b/kit.yml
@@ -1,5 +1,7 @@
 ---
 name:   vault
+version: 1.6.0
+
 author: James Hunt <jhunt@starkandwayne.com>
 code:   https://github.com/genesis-community/vault-genesis-kit
 docs:   https://genesisporject.io/kits/vault
@@ -14,4 +16,9 @@ certificates:
         valid_for: 10y
         names:
           - consul_vault_peer
+          - 127.0.0.1
+      vault:
+        valid_for: 2y
+        names:
+          - "${meta.domain}"
           - 127.0.0.1

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -1,6 +1,7 @@
 meta:
   default:
     azs: [z1, z2, z3]
+  domain: (( grab params.vault_domain || "vault.bosh" ))
 
 exodus:
   ips: (( grab instance_groups.vault.networks[0].static_ips ))
@@ -18,6 +19,9 @@ instance_groups:
             certificate: (( vault meta.vault "/certs/consul:certificate" ))
             key:         (( vault meta.vault "/certs/consul:key" ))
             ca:          (( vault meta.vault "/certs/ca:certificate" ))
+        tls:
+          certificate: (( vault meta.vault "/certs/vault:certificate" ))
+          key:         (( vault meta.vault "/certs/vault:key" ))
 
   instances: 3
   azs:       (( grab params.availability_zones || meta.default.azs ))
@@ -39,9 +43,9 @@ update:
 
 releases:
   - name:    safe
-    version: 0.2.1
-    url:     https://github.com/cloudfoundry-community/safe-boshrelease/releases/download/v0.2.1/safe-0.2.1.tgz
-    sha1:    7da89b2a385c3dfe3dc647844a61e8b531e6e54b
+    version: 0.3.0
+    url:     https://github.com/cloudfoundry-community/safe-boshrelease/releases/download/v0.3.0/safe-0.3.0.tgz
+    sha1:    ee009da0398ec1688ccfe830d68957be49571b0a
 
 stemcells:
   - alias:   default


### PR DESCRIPTION
* Bumped version of Vault to 1.4.0
* Added `params.vault_domain` to allow setting the DNS SAN for the vault certs.
* Certificates for Vault are now generted by genesis for a TTL of 2y to satisfy new browser certificate constraints ( Closes #19 )
	* You may need to run `genesis add-secrets` when upgrading to this version of the kit.