### PR TITLE
Bgrohmann/ci updates

### DIFF
--- a/ci/envs/ci.yml
+++ b/ci/envs/ci.yml
@@ -2,4 +2,3 @@
 kit:
   name: dev
   version: latest
-  features: []

--- a/ci/scripts/build-kit
+++ b/ci/scripts/build-kit
@@ -41,10 +41,9 @@ if [[ ${#check_dirs[@]} -gt 0 ]] ; then
   out="$(eval "spruce merge --skip-eval $( \
     grep -rl '^releases:' "${check_dirs[@]}" \
     | sed -e "s/\\(.*\\)/<(spruce json \\1 | jq -r '{releases: [ \"(( merge on sha1 ))\", .releases[] ]}')/" |tr "\n" " " \
-    ) | spruce json | jq -r ." )"
+  ) | spruce json | jq -r ." )"
   echo "$out" | spruce merge | spruce json | "${CI_ROOT}/ci/scripts/check-sha1s"
 fi
-
 
 header "Building $KIT_SHORTNAME kit v$VERSION"
 genesis -C "$REPO_ROOT" compile-kit -v "$VERSION" -n "$KIT_SHORTNAME"

--- a/ci/scripts/build-upstream-jobs
+++ b/ci/scripts/build-upstream-jobs
@@ -75,13 +75,18 @@ resources:
 EOF
 
 done
-(
-echo "groups:"
-echo "- (( append ))"
-echo "- name: upstream"
-echo "  jobs:"
-for job in "${update_group[@]}" ; do 
+group_file="$base_dir/pipeline/upstream/update_group.yml"
+if [[ "${#update_group[@]}" -gt 0 ]] ; then
+  (
+  echo "groups:"
+  echo "- (( merge on name ))"
+  echo "- name: upstream"
+  echo "  jobs:"
+  echo "  - (( append ))"
+  for job in ${update_group[@]+"${update_group[@]}"} ; do
   echo "  - $job"
-done
-) >> "$base_dir/pipeline/upstream/update_group.yml"
-
+  done
+  ) >> "$group_file"
+elif [[ -f "$group_file" ]] ; then
+  rm -f "$group_file"
+fi

--- a/ci/scripts/compare-release-specs
+++ b/ci/scripts/compare-release-specs
@@ -43,9 +43,8 @@ rm -rf "$workdir/compare"
 
 curr_releases="$(releases)"
 
-
-prev_rel_names="$(echo "$prev_releases"| jq -r '.releases[] | .name' | sort)"
-curr_rel_names="$(echo "$curr_releases"| jq -r '.releases[] | .name' | sort)"
+prev_rel_names="$(echo "$prev_releases"| jq -r '.releases[] | .name' | sort | uniq)"
+curr_rel_names="$(echo "$curr_releases"| jq -r '.releases[] | .name' | sort | uniq)"
 
 removed=()
 while IFS='' read -r rel ; do
@@ -59,9 +58,11 @@ done <<<"$(diff -p <(echo "$prev_rel_names") <(echo "$curr_rel_names") | grep '^
 unchanged=()
 changed=()
 while IFS='' read -r rel; do
-  prev_ver="$(echo "$prev_releases" | jq -r --arg r "$rel" '(.releases[] | select(.name == $r) | .version ) // "--none--" ' )"
+  prev_ver="$(echo "$prev_releases" | jq -r --arg r "$rel" \
+    '.releases | map(select(.name == $r) | .version) | sort | unique | if(.|length>0) then .|join(",") else "--none--" end' )"
   if [[ "$prev_ver" == "--none--" ]] ; then continue ; fi
-  curr_ver="$(echo "$curr_releases" | jq -r --arg r "$rel" '.releases[] | select(.name == $r) | .version' )"
+  curr_ver="$(echo "$curr_releases" | jq -r --arg r "$rel" \
+    '.releases | map(select(.name == $r) | .version) | sort | unique | join(",")' )"
   if [[ "$prev_ver" == "$curr_ver" ]] ; then
     unchanged+=( "$rel $curr_ver" )
   else
@@ -107,28 +108,38 @@ if [[ "${#changed[@]}" -gt 0 && -n "${changed[0]}" ]] ; then
   if [ -f "${ci_dir}/ci/upstreamrepo.yml" ]; then
     upstreamrepo=$(spruce json "${ci_dir}/ci/upstreamrepo.yml")
   else
-    upstreamrepo="[]"
+    upstreamrepo='{"repos": []}'
   fi
+  # TODO: do this in two phases -- first phase pull out all the non-compiled
+  #       versions, then run through with the compiled versions, picking up the
+  #       non-compiled version's git repo.  Also indicate if they are compiled
+  #       or not, and if so, what os is the target. (because that may change)
   repos="$(
     echo "$curr_releases" \
     | jq --argjson gitrepos "$upstreamrepo" -r 'reduce .releases[] as {$name, $url, $sha1, $version} ({repos: []};
         ($url
-        | if ($url | test("https?://s3.amazonaws.com")) then
+        | if ($url | test("https?://s3(-.*)?.amazonaws.com")) then
             ($gitrepos.repos | map(select(.name == $name))[0].repo)
-            elif ($url | test("https?://bosh.io")) then
+          elif ($url | test("https?://storage.googleapis.com")) then
+            ($gitrepos.repos | map(select(.name == $name))[0].repo)
+          elif ($url | test("https?://bosh.io")) then
             ($url | sub("^.*/d/";"https://") | sub("\\?v=.*$";""))
-            elif ($url | test("https?://github.com")) then
+          elif ($url | test("https?://github.com")) then
             ($url | sub("^.*http";"http") | sub("/releases/download/.*$";""))
-            else
+          else
             $url
-            end
+          end
         ) as $repo |
         (.repos += [{$name,$repo}])
     )')"
 
   for info in "${changed[@]}" ; do
     read -r rel prev_ver curr_ver <<<"$info"
-    repo="$(echo "$repos" | jq -r --arg r "$rel" '.repos[] | select(.name == $r) | .repo' )"
+
+    #TODO: handle multiple versions (comma separated) -- right now we're just taking the first one with a repo.
+    #TODO: handle compiled releases better -- right now just skipping.
+    repo="$(echo "$repos" | jq -r --arg r "$rel" '.repos | map(select(.name == $r and .repo != null)) | .[0].repo//""' )"
+    [[ -n "$repo" ]] || continue
     rel_dir="$workdir/releases/$rel"
     mkdir -p "$rel_dir"
     git -C "$rel_dir" init >/dev/null 2>&1 && \

--- a/ci/tasks/build-kit.yml
+++ b/ci/tasks/build-kit.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: version

--- a/ci/tasks/deploy-stable.yml
+++ b/ci/tasks/deploy-stable.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: git-latest-tag

--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: git

--- a/ci/tasks/generate-release-notes.yml
+++ b/ci/tasks/generate-release-notes.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: git

--- a/ci/tasks/get-latest-upstream.yml
+++ b/ci/tasks/get-latest-upstream.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/concourse-go
-    tag: '1.18'
+    repository: ((image/concourse_go.url))
+    tag:        ((image/concourse_go.tag))
 
 inputs:
   - name: git-ci

--- a/ci/tasks/prerelease.yml
+++ b/ci/tasks/prerelease.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: version

--- a/ci/tasks/release.yml
+++ b/ci/tasks/release.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: version

--- a/ci/tasks/spec-check.yml
+++ b/ci/tasks/spec-check.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: git

--- a/ci/tasks/spec-tests.yml
+++ b/ci/tasks/spec-tests.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/concourse-go
-    tag: '1.18'
+    repository: ((image/concourse_go.url))
+    tag:        ((image/concourse_go.tag))
 
 inputs:
 - name: git

--- a/ci/tasks/update-release.yml
+++ b/ci/tasks/update-release.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/concourse-go
-    tag: '1.18'
+    repository: ((image/concourse_go:url))
+    tag:        ((image/concourse_go:tag))
 
 inputs:
 - name: git

--- a/ci/tasks/upgrade.yml
+++ b/ci/tasks/upgrade.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: registry.ops.scalecf.net/genesis-community/genesis
-    tag: latest
+    repository: ((image/genesis.url))
+    tag:        ((image/genesis.tag))
 
 inputs:
 - name: git


### PR DESCRIPTION
Made the following fixes to vault ci : 

makes tasks use vault variables for images
clean up white space and unnecessary yml
better build groups in build-upstream-jobs
support multiple versions of named releases