### PR TITLE
Add minimal hooks/addon.pm for Vault kit

### DIFF
--- a/hooks/addon.pm
+++ b/hooks/addon.pm
@@ -1,0 +1,26 @@
+package Genesis::Hook::Addon::Vault;
+
+use v5.20;
+use warnings;
+
+# allow loading your development libs
+BEGIN {
+  push @INC,
+    $ENV{GENESIS_LIB}
+      ? $ENV{GENESIS_LIB}
+      : $ENV{HOME}.'/.genesis/lib'
+}
+
+use parent qw(Genesis::Hook::Addon);
+use Genesis qw/bail/;
+
+# init — enforce a minimum Genesis version
+sub init {
+  my ($class, %ops) = @_;
+  my $self = $class->SUPER::init(%ops);
+
+  # match the version your individual files check against
+  $self->check_minimum_genesis_version('3.1.0');
+  return $self;
+}
+1;


### PR DESCRIPTION
Introduce a stub Genesis::Hook::Addon::Vault in hooks/addon.pm that:
- Inherits from Genesis::Hook::Addon to enable automatic discovery of addon-*.pm modules
- Enforces a minimum Genesis version of 3.1.0 via check_minimum_genesis_version
- Removes any custom perform or cmd_details overrides in favor of the core discovery/dispatch logic