### PR TITLE
fix(addon-target): refactor addon-target~t.pm targeting and auth

### DIFF
--- a/hooks/addon-target~t.pm
+++ b/hooks/addon-target~t.pm
@@ -1,11 +1,7 @@
 package Genesis::Hook::Addon::Vault::Target;
-
 use v5.20;
 use warnings; # Genesis min perl version is 5.20
-use Genesis qw/bail info run/;
-# Only needed for development
-BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'./.genesis/lib'}
-
+use Genesis qw/bail info run read_json_from/;
 use parent qw(Genesis::Hook::Addon);
 sub init {
   my $class = shift;
@@ -16,67 +12,76 @@ sub init {
 
 sub cmd_details {
   return
-  "Target the Vault and authenticate via a specified auth method (defaults to token).\n".
-  "Usage: target [METHOD]\n";
+    "Target the Vault and authenticate via a specified auth method (defaults to token), interactively if needed.\n"
+  . "Usage: target [METHOD]\n";
 }
 
 sub perform {
   my ($self) = @_;
   my $env = $self->env;
+  my $env_name = $env->name;
 
   # Get the authentication method (default to 'token')
   my $method = $self->{args}[0] || 'token';
+  info("Using auth method: $method");
 
-  info("");
-
-  # Find the domain to connect to
+  # Resolve vault_domain or discover Vault IPs
   my $domain = $env->lookup('params.vault_domain', '');
 
   if (!$domain) {
-    my ($out, $rc) = run(
-      'bosh vms --json | jq -r \'.Tables[0].Rows[] | (.ips)\''
-    );
+    my ($json, $rc) = read_json_from($env->bosh->execute('vms', '--json'));
+    bail("Failed to get VM JSON ($rc)") unless $json;
 
-    my $curl_opts = $ENV{CURLOPTS} || '';
+    # collect vault/* instances
+    my @vault_ips;
+    for my $row (@{$json->{Tables}[0]{Rows}}) {
+      next unless $row->{instance} =~ /^vault\//;
+      my $ips = $row->{ips};
+      push @vault_ips, ref $ips eq 'ARRAY' ? @$ips : $ips;
+    }
+    bail("No Vault VMs found") unless @vault_ips;
+#    info("Vault IP candidates: @vault_ips");
+
     my $timeout = $ENV{TIMEOUT} || 3;
-
-    for my $ip (split(/\s+/, $out)) {
-      my ($curl_out, $curl_rc) = run(
-        { stderr => 0 },
-        'curl -Lsk ' . $curl_opts . ' -m' . $timeout . ' https://' . $ip . ' >/dev/null 2>&1'
-      );
-
+    for my $ip (@vault_ips) {
+      next unless $ip =~ /^\d+\.\d+\.\d+\.\d+$/;
+      my (undef, $curl_rc) = run({ stdout=>0, stderr=>0 }, 'curl', '-Lsk', "-m$timeout", "https://$ip");
       if ($curl_rc == 0) {
         $domain = $ip;
+#        info("Selected Vault node: $domain");
         last;
       }
     }
-
-    if (!$domain) {
-      bail("Could not find a valid Vault IP to connect to.");
-    }
+    bail("Could not find a valid Vault IP to connect to.") unless $domain;
+  }
+  else {
+#    info("Using configured domain: $domain");
   }
 
-  # Target and authenticate to Vault
-  my $env_name = $env->name;
-  run('SAFE_TARGET=\'\' safe target https://' . $domain . ' -k ' . $env_name);
-  run('safe -T ' . $env_name . ' auth ' . $method);
+  # Target Vault
+  my ($t_out, $t_rc) = run({ stderr=>1 }, 'safe', 'target', "https://$domain", '-k', $env_name);
+  bail("safe target failed") if $t_rc;
 
-  # Check if authentication was successful
-  my ($handshake_out, $handshake_rc) = run(
-    { stderr => 0 },
-    'safe -T ' . $env_name . ' read secret/handshake >/dev/null 2>&1'
-  );
+  # Authenticate (interactive if needed)
+  my $auth_cmd = "safe -T $env_name auth $method";
+  info("Running: $auth_cmd");
+  # interactive auth, capture exit code
+  my (undef, $auth_rc) = run({ interactive => 1 }, 'safe', '-T', $env_name, 'auth', $method);
+  if ($auth_rc != 0) {
+    info("Authentication failed (exit code $auth_rc)");
+    return $self->done(0);
+  }
 
-  if ($handshake_rc == 0) {
-    info("\n" . "Retrieving #Y{status} of Vault\n");
-    run('safe -T ' . $env_name . ' status');
+
+  # Verify handshake & status
+  my (undef, $h_rc) = run({ stderr=>0 }, 'safe', '-T', $env_name, 'read', 'secret/handshake');
+  if ($h_rc == 0) {
+    info("Vault is successfully targeted and authenticated.");
     return $self->done(1);
   }
 
-  info("#R{Authentication Failed} (or secret/handshake doesn't exist)\n");
-
-  return $self->done();
+  info("Authentication failed or secret/handshake missing");
+  return $self->done(0);
 }
 
 1;


### PR DESCRIPTION
- Replace shell/jq BOSH parsing with pure-Perl JSON handling via read_json_from
- Filter only vault/* instances and validate IPv4 reachability before selecting domain
- Remove unsafe string-splitting and inline redirects in curl calls
- Use Genesis::run with `interactive => 1` for `safe auth` when needed
- Bail early on `safe target` or auth failures with clear error messages